### PR TITLE
Fix incorrect reported size of `CborFloat` when using Float64 value

### DIFF
--- a/src/commonMain/kotlin/net/orandja/obor/data/CborFloat.kt
+++ b/src/commonMain/kotlin/net/orandja/obor/data/CborFloat.kt
@@ -24,7 +24,7 @@ data class CborFloat(val value: Double) : CborObject(Kind.FLOAT) {
         return if (floatValue.toDouble().toRawBits() == value.toRawBits()) {
             val float16Bits = float32ToFloat16bits(floatValue)
             if (float16BitsToFloat32(float16Bits).toRawBits() == floatValue.toRawBits()) 3 else 5
-        } else 7
+        } else 9
     }
 
     override fun describe(

--- a/src/commonTest/kotlin/net/orandja/obor/FloatingPointTests.kt
+++ b/src/commonTest/kotlin/net/orandja/obor/FloatingPointTests.kt
@@ -59,30 +59,29 @@ class FloatingPointTests {
         assertTransformation("FA007FFFFF".hex(), 1.1754942106924411e-38)
         assertTransformation("FB0000000000000001".hex(), 5.0e-324)
         assertTransformation("FBFFEFFFFFFFFFFFFF".hex(), -1.7976931348623157e+308)
-        assertTransformation("FB7FEFFFFFFFFFFFFF".hex(), 1.7976931348623157e+308)
     }
 
     @Test
-    fun doubleSize(){
+    fun doubleSize() {
         assertEquals(3, CborFloat(0.00006097555160522461).cborSize)
         assertEquals(5, CborFloat(65536.0).cborSize)
         assertEquals(9, CborFloat(1.7976931348623157e+308).cborSize)
     }
 
     @Test
-    fun describeFloat16(){
+    fun describeFloat16() {
         val desc = CborFloat(0.00006097555160522461).getObjectDescription()[0].meaning
         assertEquals("float16(6.097555160522461E-5)", desc)
     }
 
     @Test
-    fun describeFloat32(){
+    fun describeFloat32() {
         val desc = CborFloat(3.4028234663852886e+38).getObjectDescription()[0].meaning
         assertEquals("float32(3.4028234663852886E38)", desc)
     }
 
     @Test
-    fun describeFloat64(){
+    fun describeFloat64() {
         val desc = CborFloat(1.7976931348623157e+308).getObjectDescription()[0].meaning
         assertEquals("float64(1.7976931348623157E308)", desc)
     }

--- a/src/commonTest/kotlin/net/orandja/obor/FloatingPointTests.kt
+++ b/src/commonTest/kotlin/net/orandja/obor/FloatingPointTests.kt
@@ -1,6 +1,8 @@
 package net.orandja.obor
 
+import net.orandja.obor.data.CborFloat
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class FloatingPointTests {
     companion object {
@@ -57,5 +59,31 @@ class FloatingPointTests {
         assertTransformation("FA007FFFFF".hex(), 1.1754942106924411e-38)
         assertTransformation("FB0000000000000001".hex(), 5.0e-324)
         assertTransformation("FBFFEFFFFFFFFFFFFF".hex(), -1.7976931348623157e+308)
+        assertTransformation("FB7FEFFFFFFFFFFFFF".hex(), 1.7976931348623157e+308)
+    }
+
+    @Test
+    fun doubleSize(){
+        assertEquals(3, CborFloat(0.00006097555160522461).cborSize)
+        assertEquals(5, CborFloat(65536.0).cborSize)
+        assertEquals(9, CborFloat(1.7976931348623157e+308).cborSize)
+    }
+
+    @Test
+    fun describeFloat16(){
+        val desc = CborFloat(0.00006097555160522461).getObjectDescription()[0].meaning
+        assertEquals("float16(6.097555160522461E-5)", desc)
+    }
+
+    @Test
+    fun describeFloat32(){
+        val desc = CborFloat(3.4028234663852886e+38).getObjectDescription()[0].meaning
+        assertEquals("float32(3.4028234663852886E38)", desc)
+    }
+
+    @Test
+    fun describeFloat64(){
+        val desc = CborFloat(1.7976931348623157e+308).getObjectDescription()[0].meaning
+        assertEquals("float64(1.7976931348623157E308)", desc)
     }
 }


### PR DESCRIPTION
`CborFloat.cborSize()` incorrectly reports the size of a Float64 as being 7 bytes, instead of 9 bytes. This is clearly just a typo, as the actual encoded size is 9 bytes. 

This PR adds a test that demonstrates the issue, as well as the reported sizes for other float sizes (which were already correct). Also adds tests for the descriptions of the floats, as that function also also referenced 9 bytes so I wanted to make sure it still worked.